### PR TITLE
Context scope fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ meteor add timbrandin:sideburns
 
 ## Getting started
 
-#### Ideas for version 0.3
+#### Ideas for version 0.3 (Using the new Meteor toolchain)
 
 ##### Disassembled
 

--- a/sideburns-export.js
+++ b/sideburns-export.js
@@ -18,8 +18,7 @@ Sideburns.check = function(context, string) {
   if (!context) {
     return false;
   }
-  var obj = context.data;
-  var str = 'this.data';
+  var obj = context;
   _.each(tests, function(test) {
     if (!obj) {
       return false;

--- a/sideburns-export.js
+++ b/sideburns-export.js
@@ -14,6 +14,7 @@ Sideburns.classNames.prototype.toString = Sideburns.classNames.prototype.toHTML 
 };
 
 Sideburns.check = function(context, string) {
+  var string = string.trim();
   var tests = string.split('.');
   if (!context) {
     return false;

--- a/sideburns.js
+++ b/sideburns.js
@@ -92,51 +92,51 @@ var handler = function (compileStep) {
     /* START SPACEBARS */
 
     // Add return and key={index} inside {{#each}}.
-    markup = markup.replace(/({{#each\s+[^}]+}}[^<]*)(<\w+)/g, '$1let context=arguments[0];return ($2 key={index}');
+    markup = markup.replace(/({{#each\s+[^}]+}}[^<]*)(<\w+)/g, '$1return ($2 key={index}');
     // {{#each}} in
-    markup = markup.replace(/{{#each\s+([^\s]+)\s+in\s+([^}]+)\s*}}/g, "{(Sideburns.check(this, '$2')? this.data.$2 : []).map(function($1, index){");
+    markup = markup.replace(/{{#each\s+([^\s]+)\s+in\s+([^}]+)\s*}}/g, "{(Sideburns.check(context, '$2')? context.$2 : []).map(function($1, index){let context=__component.data;context.$1=$1");
     // {{/each}}
     markup = markup.replace(/{{\/each}}/g, ");})}");
 
     // ^{{#if}}
-    markup = markup.replace(/^\W*{{#if\s+(\w+)\s*}}/g, "<span>{Sideburns.check(this, '$1')?(");
+    markup = markup.replace(/^\W*{{#if\s+(\w+)\s*}}/g, "<span>{Sideburns.check(context, '$1')?(");
     // {{/if}}$
     markup = markup.replace(/{{\/if}}\W*$/g, "):''}</span>");
     // {{#if}}
-    markup = markup.replace(/{{#if\s+(\w+)\s*}}/g, "{Sideburns.check(this, '$1')?(");
+    markup = markup.replace(/{{#if\s+(\w+)\s*}}/g, "{Sideburns.check(context, '$1')?(");
     // {{else}} {{/if}}
     markup = markup.replace(/(?:{{else}}(?![\w\W]*{{else}}))([\w\W]*){{\/if}}/g, "):($1)}");
     // {{/if}}
     markup = markup.replace(/{{\/if}}/g, "):''}");
 
     // ^{{#unless}}
-    markup = markup.replace(/^\W*{{#unless\s+(\w+)\s*}}/g, "<span>{!Sideburns.check(this, '$1')?(");
+    markup = markup.replace(/^\W*{{#unless\s+(\w+)\s*}}/g, "<span>{!Sideburns.check(context, '$1')?(");
     // {{/unless}}$
     markup = markup.replace(/{{\/unless}}\W*$/g, "):''}</span>");
     // {{#unless}}
-    markup = markup.replace(/{{#unless\s+(\w+)\s*}}/g, "{!Sideburns.check(this, '$1')?(");
+    markup = markup.replace(/{{#unless\s+(\w+)\s*}}/g, "{!Sideburns.check(context, '$1')?(");
     // {{else}} {{/unless}}
     markup = markup.replace(/(?:{{else}}(?![\w\W]*{{else}}))([\w\W]*){{\/unless}}/g, "):($1)}");
     // {{/unless}}
     markup = markup.replace(/{{\/unless}}/g, "):''}");
 
     // {{helper}} raw HTML
-    markup = markup.replace(/{{{([^}]*)}}}/g, "{Sideburns.check(this, '$1')? this.data.$1 : ''}");
+    markup = markup.replace(/{{{([^}]*)}}}/g, "{Sideburns.check(context, '$1')? context.data.$1 : ''}");
 
     // {{helper}} SafeString – Dynamic Attribute (class)
-    markup = markup.replace(/\sclass={{([^}]*)}}/g, " className={Sideburns.check(this, '$1')? new Sideburns.classNames(this.data.$1) : ''}");
+    markup = markup.replace(/\sclass={{([^}]*)}}/g, " className={Sideburns.check(context, '$1')? new Sideburns.classNames(context.$1) : ''}");
 
     // {{helper}} SafeString – Dynamic Attribute (other)
-    markup = markup.replace(/={{([^}]*)}}/g, "={Sideburns.check(this, '$1')? new Sideburns.SafeString(this.data.$1) : ''}");
+    markup = markup.replace(/={{([^}]*)}}/g, "={Sideburns.check(context, '$1')? new Sideburns.SafeString(context.$1) : ''}");
 
     // {{helper}} SafeString – In Attribute Values (class)
-    markup = markup.replace(/\sclass="([^\"{]*){{([^}]*)}}([^\"{]*)\"/g, " className={Sideburns.check(this, '$2')? '$1' + new Sideburns.classNames(this.data.$2) + '$3' : ''}");
+    markup = markup.replace(/\sclass="([^\"{]*){{([^}]*)}}([^\"{]*)\"/g, " className={Sideburns.check(context, '$2')? '$1' + new Sideburns.classNames(context.$2) + '$3' : ''}");
 
     // {{helper}} SafeString – In Attribute Values (other)
-    markup = markup.replace(/="([^\"{]*){{([^}]*)}}([^\"{]*)\"/g, "={Sideburns.check(this, '$2')? '$1' + new Sideburns.classNames(this.data.$2) + '$3' : ''}");
+    markup = markup.replace(/="([^\"{]*){{([^}]*)}}([^\"{]*)\"/g, "={Sideburns.check(context, '$2')? '$1' + new Sideburns.classNames(context.$2) + '$3' : ''}");
 
     // {{helper}} SafeString
-    markup = markup.replace(/{{([^}]*)}}/g, "{Sideburns.check(this, '$1')? new Sideburns.SafeString(this.data.$1) : ''}");
+    markup = markup.replace(/{{([^}]*)}}/g, "{Sideburns.check(context, '$1')? new Sideburns.SafeString(context.$1) : ''}");
 
     /* END SPACEBARS */
 
@@ -169,6 +169,7 @@ var handler = function (compileStep) {
     jsx += "  },\n";
     jsx += "  render: function() {\n";
     jsx += "    let __component = this;";
+    jsx += "    let context = this.data;";
     jsx += "    return (" + markup + ");";
     jsx += "  }\n";
     jsx += "};\n";


### PR DESCRIPTION
This is a fix for #11. The context was missing when using {{ var }} inside a {{#each in}} loop.
I think it is better idea to create a context variable in every block scope instead of using this.data.

There was also a problem with variables and whitespace. I have added a small fix for that too