### PR TITLE
change event argument order

### DIFF
--- a/sideburns.js
+++ b/sideburns.js
@@ -81,7 +81,7 @@ var handler = function (compileStep) {
           // Remove duplicate listeners.
           $(select).removeAttr(eventName);
           // Append new listener.
-          $(select).attr(eventName, "{__component.events['" + key + "'].bind(__component, typeof context != 'undefined' ? context : (this.data ? this.data : this))}");
+          $(select).attr(eventName, "{eventHandler.bind(__component, '" + key + "', typeof context != 'undefined' ? context : (this.data ? this.data : this))}");
           markup = $.html();
         }
       }
@@ -169,6 +169,9 @@ var handler = function (compileStep) {
     jsx += "  },\n";
     jsx += "  render: function() {\n";
     jsx += "    let __component = this;";
+    jsx += "    function eventHandler(key,context,event){";
+    jsx += "        __component.events[key].call(this,event,context);";
+    jsx += "    }";
     jsx += "    return (" + markup + ");";
     jsx += "  }\n";
     jsx += "};\n";


### PR DESCRIPTION
The event parameter of an event is currently added as the last argument. Which isn't the order that blaze uses so I made a little fix for it.